### PR TITLE
Make it easier to specify ECR images with docker plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,22 @@ can be found in https://docs.docker.com/config/containers/resource_constraints/#
 
 Example: `0`
 
+### `prepend-ecr-domain` (optional, boolean)
+
+If set to true, prepends the ECR domain `ecr-account-id`.dkr.ecr.`ecr-region`.amazonaws.com/ to the `image` parameter.
+
+### `ecr-account-id` (optional, string)
+
+AWS account ID to use in the ECR domain. Defaults to the current account id determined using `aws sts get-caller-identity`. Has no effect if `prepend-ecr-domain` is not set to true.
+
+Example: `123456789012`
+
+### `ecr-region` (optional, string)
+
+AWS region to use in the ECR domain. Defaults to `AWS_DEFAULT_REGION` environment variable on the agent. Has no effect if `prepend-ecr-domain` is not set to true.
+
+Example: `us-east-1`
+
 ## Developing
 
 To run testing, shellchecks and plugin linting use use `bk run` with the [Buildkite CLI](https://github.com/buildkite/cli).

--- a/hooks/command
+++ b/hooks/command
@@ -365,10 +365,31 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_PROPAGATE_AWS_AUTH_TOKENS:-false}" =~ ^(true|on
   fi
 fi
 
+image="${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+# Handle ECR domain prefix
+if [[ -n "${BUILDKITE_PLUGIN_DOCKER_PREPEND_ECR_DOMAIN:-}" ]] ; then
+  ecr_region="${BUILDKITE_PLUGIN_DOCKER_ECR_REGION:-${AWS_DEFAULT_REGION:-}}"
+  if [[ -z $ecr_region ]]; then
+    echo "+++ 🚨 AWS region should be specified via plugin config or AWS_DEFAULT_REGION environment."
+    exit 1
+  fi
+
+  ecr_account_id="${BUILDKITE_PLUGIN_DOCKER_ECR_ACCOUNT_ID:-}"
+  if [[ -z $ecr_account_id ]]; then
+    ecr_account_id="$(aws sts get-caller-identity --query Account --output text)"
+  fi
+  if [[ -z $ecr_account_id ]]; then
+    echo >&2 "AWS account ID required via plugin config or 'aws sts get-caller-identity'"
+    exit 1
+  fi
+
+  image="${ecr_account_id}.dkr.ecr.${ecr_region}.amazonaws.com/${image}"
+fi
+
 if [[ "${BUILDKITE_PLUGIN_DOCKER_ALWAYS_PULL:-false}" =~ ^(true|on|1)$ ]] ; then
-  echo "--- :docker: Pulling ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+  echo "--- :docker: Pulling ${image}"
   if ! retry "${BUILDKITE_PLUGIN_DOCKER_PULL_RETRIES:-3}" \
-       docker pull "${BUILDKITE_PLUGIN_DOCKER_IMAGE}" ; then
+       docker pull "${image}" ; then
     echo "!!! :docker: Pull failed."
     exit "$retry_exit_status"
   fi
@@ -487,7 +508,7 @@ fi
 args+=("--label" "com.buildkite.job-id=${BUILDKITE_JOB_ID}")
 
 # Add the image in before the shell and command
-args+=("${BUILDKITE_PLUGIN_DOCKER_IMAGE}")
+args+=("${image}")
 
 # Set a default shell if one is needed
 if [[ -z $shell_disabled ]] && [[ ${#shell[@]} -eq 0 ]] ; then
@@ -534,7 +555,7 @@ elif [[ ${#command[@]} -gt 0 ]] ; then
   done
 fi
 
-echo "--- :docker: Running command in ${BUILDKITE_PLUGIN_DOCKER_IMAGE}"
+echo "--- :docker: Running command in ${image}"
 echo -ne '\033[90m$\033[0m docker run ' >&2
 
 # Print all the arguments, with a space after, properly shell quoted

--- a/plugin.yml
+++ b/plugin.yml
@@ -99,6 +99,12 @@ configuration:
       type: array
     ulimits:
       type: array
+    prepend-ecr-domain:
+      type: boolean
+    ecr-account-id:
+      type: string
+    ecr-region:
+      type: string
   required:
     - image
   additionalProperties: false


### PR DESCRIPTION
Add plugin parameters `prepend-ecr-domain`, `ecr-account-id` and `ecr-region` to make it easier to reference Docker images from ECR repositories.

In particular, my main use case is that we have agents running in multiple AWS regions, and we configure ECR replication such that all our images should be available on the same region that the agents are running. In this setup, it is desired to specify an image URI from the same region as the agent is running at. However, this is currently not possible to achieve without knowing, beforehand, the region where the agent that will pick up the job is running, as the region needs to be explicitly encoded in the image URI.

This PR makes it possible to do that by making it, by default, auto-determine the region portion from the `AWS_DEFAULT_REGION` environment variable. It also makes the very common case of "just use the same region and same account id" very easy to handle, by simply setting `prepend-ecr-domain` to true.